### PR TITLE
convert 'tostring' to 'tobytes' in png.py

### DIFF
--- a/png.py
+++ b/png.py
@@ -169,7 +169,7 @@ def isarray(x):
     return isinstance(x, array)
 
 def tostring(row):
-    return row.tostring()
+    return row.tobytes()
 
 def interleave_planes(ipixels, apixels, ipsize, apsize):
     """


### PR DESCRIPTION
Error: AttributeError: 'array.array' object has no attribute 'tostring'

Replaced tostring() with tobytes() - Now works with Python 3.9.1.